### PR TITLE
Use clj-http to avoid 403 error

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,4 @@
 {:deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.clojure/data.json {:mvn/version "1.0.0"}}}
+  org.clojure/data.json {:mvn/version "1.0.0"}
+  clj-http {:mvn/version "3.10.1"}}}

--- a/src/mermaid_clj/core.clj
+++ b/src/mermaid_clj/core.clj
@@ -1,7 +1,9 @@
 (ns mermaid-clj.core
   (:require [clojure.data.json :as json]
-            [clojure.java.shell :as shell])
-  (:import java.util.Base64))
+            [clojure.java.shell :as shell]
+            [clj-http.client :as client])
+  (:import java.util.Base64
+           [java.io File]))
 
 (def direction->mermaid
   ;; Type   Meaning                      Description
@@ -190,13 +192,17 @@
               :env (assoc current-env "BROWSER" "firefox"))))
 
 (defn download-image
-  [diagram]
-  (let [current-env (into {} (System/getenv))]
-    (spit "/tmp/output.png" (slurp (format mermaid-img
-                                           (encode-base64
-                                            (json/write-str
-                                             {:code diagram
-                                              :mermaid {:theme "default"}})))))))
+  ([diagram]
+   (download-image diagram "/tmp/output.png"))
+  ([diagram destination]
+   (let [url (format mermaid-img
+                     (encode-base64
+                       (json/write-str
+                         {:code diagram
+                          :mermaid {:theme "default"}})))]
+     (clojure.java.io/copy
+       (:body (client/get url {:as :stream}))
+       (File. destination)))))
 
 (comment
   (def sample


### PR DESCRIPTION
Slurp returns a 403 when trying to download the image, the same error can be reproduced using [replit](https://repl.it/repls/LowSatisfiedScans#main.clj).
I'm not sure the root cause, maybe because slurp is not able to handle binary data.
This PR uses clj-http to download the image, fixing this problem.

_Bonus_: add support to choose the destination path of an image download. 